### PR TITLE
Remove old terminal reference, update buildah command

### DIFF
--- a/content/modules/ROOT/pages/04-commit.adoc
+++ b/content/modules/ROOT/pages/04-commit.adoc
@@ -24,7 +24,7 @@ view as podman.
 
 [source,bash,run]
 ----
-buildah image list
+buildah images
 ----
 
 However, they have different views of active containers. The working

--- a/content/modules/ROOT/pages/05-run.adoc
+++ b/content/modules/ROOT/pages/05-run.adoc
@@ -14,10 +14,15 @@ You can now play the Moon Buggy game, which is a text-based version of
 the popular Moon Patrol. When you are finished, use the `+q+` command to
 quit the game, which will terminate the container.
 
+////
+Removing this block until we decide to add a second terminal to mirror
+the original lab
+
 Alternatively you can use `+podman+` to kill the running container from
 *Terminal 2*.
 
-[source,bash,run]
+[source,sh]
 ----
 podman kill $(podman ps | grep -v CONTAINER | cut -f1 -d" " )
 ----
+////


### PR DESCRIPTION
Comment out left over reference to second terminal from original lab (in case we do want to provide it later)

Buildah image command was wrong, probably copy/paste error