### PR TITLE
Update image to RHEL 10.2 (rhel-10-2-eus-06-08-26)

### DIFF
--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -6,6 +6,7 @@ virtualmachines:
     memory: "4G"
     cores: 1
     image_size: "40G"
+    register_satellite: false
     tags:
       - key: "AnsibleGroup"
         value: "bastions"

--- a/setup-automation/setup-rhel.sh
+++ b/setup-automation/setup-rhel.sh
@@ -5,7 +5,7 @@ subscription-manager clean
 subscription-manager register --activationkey=12-5-22-instruqt --org=12451665 --force
 
 # Install packages 
-sudo dnf install -y buildah
+sudo dnf install -y buildah podman
 
 # Clone the app repo to the user directory
 su - rhel -c "git clone https://github.com/ellisonleao/clumsy-bird"

--- a/setup-automation/setup-rhel.sh
+++ b/setup-automation/setup-rhel.sh
@@ -4,6 +4,9 @@
 subscription-manager clean
 subscription-manager register --activationkey=12-5-22-instruqt --org=12451665 --force
 
+# Install packages 
+sudo dnf install -y buildah
+
 # Clone the app repo to the user directory
 su - rhel -c "git clone https://github.com/ellisonleao/clumsy-bird"
 

--- a/setup-automation/setup-rhel.sh
+++ b/setup-automation/setup-rhel.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 # Clone the app repo to the user directory
+# Unregister and register the VM
+subscription-manager clean
+subscription-manager register --activationkey=12-5-22-instruqt --org=12451665 --force
+
 su - rhel -c "git clone https://github.com/ellisonleao/clumsy-bird"
 
 echo "DONE" >> /root/post-run.log

--- a/setup-automation/setup-rhel.sh
+++ b/setup-automation/setup-rhel.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# Clone the app repo to the user directory
 # Unregister and register the VM
 subscription-manager clean
 subscription-manager register --activationkey=12-5-22-instruqt --org=12451665 --force
 
+# Clone the app repo to the user directory
 su - rhel -c "git clone https://github.com/ellisonleao/clumsy-bird"
 
 echo "DONE" >> /root/post-run.log

--- a/setup-automation/setup-rhel.sh
+++ b/setup-automation/setup-rhel.sh
@@ -5,7 +5,7 @@ subscription-manager clean
 subscription-manager register --activationkey=12-5-22-instruqt --org=12451665 --force
 
 # Install packages 
-sudo dnf install -y buildah podman
+sudo dnf install -y buildah podman git
 
 # Clone the app repo to the user directory
 su - rhel -c "git clone https://github.com/ellisonleao/clumsy-bird"


### PR DESCRIPTION
## Summary
- Updated `instances.yaml` image to `rhel-10-2-eus-06-08-26`
- Disabled satellite registration (`register_satellite: false`)
- Commented out packages block
- Added subscription-manager clean & re-register to `setup-rhel.sh`
- Part of RHEL 10.2 lab migration

## Lab
Build container images with Red Hat Enterprise Linux container tools